### PR TITLE
Remove Increment comments

### DIFF
--- a/cg-app/stacks/restyled.760048635536/us-east-1/global/iam.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/global/iam.yaml
@@ -1,2 +1,1 @@
 Template: security/iam.yaml
-# Increment to deploy template-only changes: v1

--- a/cg-app/stacks/restyled.760048635536/us-east-1/mgmt/check-redis-url.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/mgmt/check-redis-url.yaml
@@ -13,5 +13,3 @@ Parameters:
     Value: check-redis-url
   - Name: ScheduleExpression
     Value: rate(10 minutes)
-
-# Increment to deploy template-only changes: v2

--- a/cg-app/stacks/restyled.760048635536/us-east-1/mgmt/forward-logs.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/mgmt/forward-logs.yaml
@@ -3,5 +3,3 @@ Template: mgmt/forward-logs.yaml
 Parameters:
   - Name: LogDNACloudWatchVersion
     Value: v2.2.1
-
-# Increment to deploy template-only changes: v4

--- a/cg-app/stacks/restyled.760048635536/us-east-1/mgmt/record-metrics.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/mgmt/record-metrics.yaml
@@ -11,5 +11,3 @@ Parameters:
     Value: src/record-metrics/72cedb92d9dd16fa36588cf788593434b37a3def.zip
   - Name: ScheduleExpression
     Value: rate(1 minute)
-
-# Increment to deploy template-only changes: v1

--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/alarms.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/alarms.yaml
@@ -4,6 +4,10 @@ Tags:
   - Key: Environment
     Value: prod
 
+  # Temporarily avoid any updates on this resource
+  - Key: "CloudGenesis:stack-file"
+    Value: "stacks/restyled.760048635536/us-east-1/prod/alarms.yaml"
+
 Parameters:
   - Name: Environment
     Value: prod

--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/alarms.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/alarms.yaml
@@ -11,5 +11,3 @@ Parameters:
     Value: 200
   - Name: QueueDepthPeriod
     Value: 120
-
-# Increment to deploy template-only changes: v4

--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/restyler-log-group.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/restyler-log-group.yaml
@@ -7,4 +7,3 @@ Parameters:
     Value: restyler
   - Name: RetentionInDays
     Value: 14
-# Increment to deploy template-only changes: v1

--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/restyle-machines.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/restyle-machines.yaml
@@ -38,5 +38,3 @@ Parameters:
     Value: /restyled/prod/redis-url
   - Name: DatadogApiKey
     Value: /restyled/prod/dd-api-key
-
-# Increment to deploy template-only changes: v6

--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/restyle-machines.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/restyle-machines.yaml
@@ -38,3 +38,5 @@ Parameters:
     Value: /restyled/prod/redis-url
   - Name: DatadogApiKey
     Value: /restyled/prod/dd-api-key
+
+# Increment to deploy template-only changes: v6

--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/sync-marketplace.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/sync-marketplace.yaml
@@ -17,5 +17,3 @@ Parameters:
     Value: rate(5 minutes)
   - Name: RestyledImage
     Value: restyled/restyled.io:0c53559
-
-# Increment to deploy template-only changes: v5

--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/vpc.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/vpc.yaml
@@ -4,6 +4,10 @@ Tags:
   - Key: Environment
     Value: prod
 
+  # Temporarily avoid any updates on this resource
+  - Key: "CloudGenesis:stack-file"
+    Value: "stacks/restyled.760048635536/us-east-1/prod/vpc.yaml"
+
 Parameters:
   - Name: Environment
     Value: prod

--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/vpc.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/vpc.yaml
@@ -7,5 +7,3 @@ Tags:
 Parameters:
   - Name: Environment
     Value: prod
-
-# Increment to deploy template-only changes: v1


### PR DESCRIPTION
Stackctl sees template changes and deploys affected stacks, unlike
CloudGenesis, so we no longer need this.
