### PR TITLE
Update restyled-machines template

### DIFF
--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/restyle-machines.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/restyle-machines.yaml
@@ -1,42 +1,24 @@
 Template: services/ec2/asg.yaml
 
-Tags:
-  - Key: Environment
-    Value: prod
-  - Key: App
-    Value: restyle-machines
-
 Parameters:
-  - Name: Environment
-    Value: prod
-  - Name: Name
-    Value: restyle-machines
-  - Name: InstanceType
-    Value: t2.small
-  - Name: UserDataSourceKey
-    Value: src/restyle-machines/user-data/737b4ec724e2710acb34956a960d31fb0edbfe1f
+  Environment: prod
+  Name: restyle-machines
+  InstanceType: t2.small
+  UserDataSourceKey: src/restyle-machines/user-data/737b4ec724e2710acb34956a960d31fb0edbfe1f
 
-  - Name: DesiredCapacity
-    Value: 1
-  - Name: ScaleUpThreshold
-    Value: 30
-  - Name: ScaleUpCapacity
-    Value: 3
+  DesiredCapacity: 1
+  ScaleUpThreshold: 30
+  ScaleUpCapacity: 3
 
-  - Name: RestylerQueueName
-    Value: restyled:agent:webhooks
-  - Name: RestylerPoolSize
-    Value: 3
+  RestylerQueueName: restyled:agent:webhooks
+  RestylerPoolSize: 3
 
-  - Name: GitHubAppId
-    Value: /restyled/prod/github-app-id
-  - Name: GitHubAppKey
-    Value: /restyled/prod/github-app-key
-  - Name: RestyledToken
-    Value: /restyled/prod/restyled-api-token
-  - Name: RedisUrl
-    Value: /restyled/prod/redis-url
-  - Name: DatadogApiKey
-    Value: /restyled/prod/dd-api-key
+  GitHubAppId: /restyled/prod/github-app-id
+  GitHubAppKey: /restyled/prod/github-app-key
+  RestyledToken: /restyled/prod/restyled-api-token
+  RedisUrl: /restyled/prod/redis-url
+  DatadogApiKey: /restyled/prod/dd-api-key
 
-# Increment to deploy template-only changes: v6
+Tags:
+  Environment: prod
+  App: restyle-machines

--- a/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/restyle-machines.yaml
+++ b/cg-app/stacks/restyled.760048635536/us-east-1/prod/services/restyle-machines.yaml
@@ -22,3 +22,6 @@ Parameters:
 Tags:
   Environment: prod
   App: restyle-machines
+
+  # Temporarily avoid any updates on this resource
+  "CloudGenesis:stack-file": "stacks/restyled.760048635536/us-east-1/prod/services/restyle-machines.yaml"


### PR DESCRIPTION
- Use object syntax
- Remove unnecessary increment comment

This will rotate the ASG due to an AMI update, which is also good. The
currently-deployed AMI (in case we need to roll back) is
`ami-0dc67873410203528`
